### PR TITLE
github actions workflows test

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -1,0 +1,48 @@
+name: Java-Maven-Workflow
+
+on:
+  push:
+    branches: ["main", "testing"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  jdk-maven-dependencies:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: defined sdk
+        uses: actions/setup-java@v4
+        with:
+          java-version: "21"
+          distribution: "temurin"
+          architecture: x64
+          cache: maven
+
+      - name: Maven install dependencies
+        run: mvn clean install --batch-mode --update-snapshots verify
+
+        working-directory: ./App
+
+  check-pass-testing:
+    needs: jdk-maven-dependencies
+
+    if: ${{success()}}
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: run test
+        run: nvm test
+        working-directory: ./App
+
+      - name: build
+        run: nvm clean package
+        working-directory: ./App
+
+      - name: upload-jar
+        run: mkdir staging && cp =r ./App/target/*.jar staging
+      - uses: actions/upload-artifact@v4
+        with:
+          name: Package
+          path: staging

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -39,7 +39,7 @@ jobs:
           path: staging
 
   realise-jar-actions:
-    needs: jdk-maven-dependencies
+    needs: dependencies-run-tests
 
     if: ${{success()}}
 

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -21,7 +21,6 @@ jobs:
 
       - name: Maven install dependencies
         run: mvn clean install --batch-mode --update-snapshots verify
-
         working-directory: ./App
 
   check-pass-testing:
@@ -33,11 +32,11 @@ jobs:
 
     steps:
       - name: run test
-        run: nvm test
+        run: mvn test
         working-directory: ./App
 
       - name: build
-        run: nvm clean package
+        run: mvn clean package
         working-directory: ./App
 
       - name: upload-jar

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -32,7 +32,7 @@ jobs:
         working-directory: ./App
 
       - name: upload-jar
-        run: mkdir staging && cp =r ./App/target/*.jar staging
+        run: mkdir staging && cp -r ./App/target/*.jar staging
       - uses: actions/upload-artifact@v4
         with:
           name: Package

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -7,7 +7,7 @@ on:
     branches: ["main"]
 
 jobs:
-  jdk-maven-dependencies:
+  dependencies-run-tests:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -23,15 +23,7 @@ jobs:
         run: mvn clean install --batch-mode --update-snapshots verify
         working-directory: ./App
 
-  check-pass-testing:
-    needs: jdk-maven-dependencies
-
-    if: ${{success()}}
-
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: run test
+      - name: run test controllers
         run: mvn test
         working-directory: ./App
 
@@ -45,3 +37,16 @@ jobs:
         with:
           name: Package
           path: staging
+
+  realise-jar-actions:
+    needs: jdk-maven-dependencies
+
+    if: ${{success()}}
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: download binary jar
+        uses: actions/download-artifact@v4
+        with:
+          name: Package

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -33,6 +33,7 @@ jobs:
 
       - name: upload-jar
         run: mkdir staging && cp -r ./App/target/*.jar staging
+
       - uses: actions/upload-artifact@v4
         with:
           name: Package
@@ -41,12 +42,31 @@ jobs:
   realise-jar-actions:
     needs: dependencies-run-tests
 
-    if: ${{success()}}
+    if: ${{success() && github.ref == 'refs/heads/main'}}
 
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
 
     steps:
       - name: download binary jar
         uses: actions/download-artifact@v4
         with:
           name: Package
+          path: ./deploy
+      - name: show download file jar
+        run: ls -R ./deploy
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: latest
+          name: Latest Release
+          body: "Automated release from main branch."
+          files: ./deploy/*.jar # Matches the path from the download step
+          draft: false
+          prerelease: false
+          make_latest: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for building and releasing a Java Maven project. The workflow automates dependency installation, testing, packaging, and artifact release for the project, streamlining the CI/CD process.

**CI/CD Workflow Automation:**

* Added a new workflow file `.github/workflows/maven.yaml` that triggers on pushes to `main` and `testing` branches, and on pull requests to `main`.
* Configured a job to set up Java 21, install dependencies, run tests, build the project, and upload the resulting JAR artifact using Maven in the `./App` directory.
* Added a release job that depends on the successful completion of tests and build, which downloads the JAR artifact and creates a GitHub release with the built JAR when changes are pushed to the `main` branch.