### PR TITLE
Employee

### DIFF
--- a/App/src/main/java/gym/vitae/controller/PersonalController.java
+++ b/App/src/main/java/gym/vitae/controller/PersonalController.java
@@ -102,6 +102,8 @@ public class PersonalController extends BaseController {
   /** Crea un nuevo empleado usando el repository. */
   public EmpleadoDetalleDTO createEmpleado(EmpleadoCreateDTO dto) {
     validateEmpleadoCreate(dto);
+    validateCedulaNoDuplicada(dto.cedula(), null);
+    validateNombresApellidosNoDuplicados(dto.nombres(), dto.apellidos(), null);
 
     Cargo cargo =
         cargoRepository
@@ -121,6 +123,8 @@ public class PersonalController extends BaseController {
   /** Actualiza un empleado existente. */
   public EmpleadoDetalleDTO updateEmpleado(int id, EmpleadoUpdateDTO dto) {
     validateEmpleadoUpdate(id, dto);
+    validateCedulaNoDuplicada(dto.cedula(), id);
+    validateNombresApellidosNoDuplicados(dto.nombres(), dto.apellidos(), id);
 
     Empleado empleado =
         empleadoRepository
@@ -288,6 +292,34 @@ public class PersonalController extends BaseController {
     }
     if (dto.estado() == null) {
       throw new IllegalArgumentException("El estado es obligatorio");
+    }
+  }
+
+  /**
+   * Valida que la cédula no esté duplicada.
+   *
+   * @param cedula Cédula a validar
+   * @param idActual ID del empleado actual (null si es creación)
+   */
+  private void validateCedulaNoDuplicada(String cedula, Integer idActual) {
+    if (empleadoRepository.existsByCedula(cedula, idActual)) {
+      throw new IllegalArgumentException(
+          "Cédula existente en otro Empleado, verifique o ingrese otro valor");
+    }
+  }
+
+  /**
+   * Valida que los nombres y apellidos no estén duplicados.
+   *
+   * @param nombres Nombres a validar
+   * @param apellidos Apellidos a validar
+   * @param idActual ID del empleado actual (null si es creación)
+   */
+  private void validateNombresApellidosNoDuplicados(
+      String nombres, String apellidos, Integer idActual) {
+    if (empleadoRepository.existsByNombresApellidos(nombres, apellidos, idActual)) {
+      throw new IllegalArgumentException(
+          "Nombres y apellidos existentes en otro Empleado, verifique o ingrese otros valores");
     }
   }
 }

--- a/App/src/main/java/gym/vitae/mapper/EmpleadoMapper.java
+++ b/App/src/main/java/gym/vitae/mapper/EmpleadoMapper.java
@@ -9,6 +9,7 @@ import gym.vitae.model.dtos.empleado.EmpleadoCreateDTO;
 import gym.vitae.model.dtos.empleado.EmpleadoDetalleDTO;
 import gym.vitae.model.dtos.empleado.EmpleadoListadoDTO;
 import gym.vitae.model.dtos.empleado.EmpleadoUpdateDTO;
+import gym.vitae.model.enums.EstadoEmpleado;
 import java.util.List;
 
 /**
@@ -168,7 +169,8 @@ public class EmpleadoMapper {
     empleado.setCargo(cargo);
     empleado.setTipoContrato(dto.tipoContrato());
     empleado.setFechaIngreso(dto.fechaIngreso());
-    empleado.setEstado(dto.estado());
+    // Estado por defecto ACTIVO si no se especifica
+    empleado.setEstado(dto.estado() != null ? dto.estado() : EstadoEmpleado.ACTIVO);
 
     return empleado;
   }

--- a/App/src/main/java/gym/vitae/repositories/ClienteRepository.java
+++ b/App/src/main/java/gym/vitae/repositories/ClienteRepository.java
@@ -283,6 +283,57 @@ public record ClienteRepository(DBConnectionManager db) implements IRepository<C
         });
   }
 
+  /**
+   * Verifica si existe un cliente con la cédula especificada.
+   *
+   * @param cedula Cédula a verificar
+   * @param excludeId ID a excluir de la búsqueda (para updates), puede ser null
+   * @return true si existe otro cliente con esa cédula
+   */
+  public boolean existsByCedula(String cedula, Integer excludeId) {
+    return TransactionHandler.inTransaction(
+        db,
+        em -> {
+          String jpql = "SELECT COUNT(c) FROM Cliente c WHERE c.cedula = :cedula";
+          if (excludeId != null) {
+            jpql += " AND c.id <> :excludeId";
+          }
+          TypedQuery<Long> q = em.createQuery(jpql, Long.class);
+          q.setParameter("cedula", cedula.trim());
+          if (excludeId != null) {
+            q.setParameter("excludeId", excludeId);
+          }
+          return q.getSingleResult() > 0;
+        });
+  }
+
+  /**
+   * Verifica si existe un cliente con los mismos nombres y apellidos.
+   *
+   * @param nombres Nombres a verificar
+   * @param apellidos Apellidos a verificar
+   * @param excludeId ID a excluir de la búsqueda (para updates), puede ser null
+   * @return true si existe otro cliente con esos nombres y apellidos
+   */
+  public boolean existsByNombresApellidos(String nombres, String apellidos, Integer excludeId) {
+    return TransactionHandler.inTransaction(
+        db,
+        em -> {
+          String jpql =
+              "SELECT COUNT(c) FROM Cliente c WHERE LOWER(c.nombres) = LOWER(:nombres) AND LOWER(c.apellidos) = LOWER(:apellidos)";
+          if (excludeId != null) {
+            jpql += " AND c.id <> :excludeId";
+          }
+          TypedQuery<Long> q = em.createQuery(jpql, Long.class);
+          q.setParameter("nombres", nombres.trim());
+          q.setParameter("apellidos", apellidos.trim());
+          if (excludeId != null) {
+            q.setParameter("excludeId", excludeId);
+          }
+          return q.getSingleResult() > 0;
+        });
+  }
+
   @Override
   public boolean equals(Object obj) {
     if (obj == this) return true;

--- a/App/src/main/java/gym/vitae/repositories/EmpleadoRepository.java
+++ b/App/src/main/java/gym/vitae/repositories/EmpleadoRepository.java
@@ -331,4 +331,55 @@ public record EmpleadoRepository(DBConnectionManager db) implements IRepository<
           return EmpleadoMapper.toListadoDTOList(empleados);
         });
   }
+
+  /**
+   * Verifica si existe un empleado con la cédula especificada.
+   *
+   * @param cedula Cédula a verificar
+   * @param excludeId ID a excluir de la búsqueda (para updates), puede ser null
+   * @return true si existe otro empleado con esa cédula
+   */
+  public boolean existsByCedula(String cedula, Integer excludeId) {
+    return TransactionHandler.inTransaction(
+        db,
+        em -> {
+          String jpql = "SELECT COUNT(e) FROM Empleado e WHERE e.cedula = :cedula";
+          if (excludeId != null) {
+            jpql += " AND e.id <> :excludeId";
+          }
+          TypedQuery<Long> q = em.createQuery(jpql, Long.class);
+          q.setParameter("cedula", cedula.trim());
+          if (excludeId != null) {
+            q.setParameter("excludeId", excludeId);
+          }
+          return q.getSingleResult() > 0;
+        });
+  }
+
+  /**
+   * Verifica si existe un empleado con los mismos nombres y apellidos.
+   *
+   * @param nombres Nombres a verificar
+   * @param apellidos Apellidos a verificar
+   * @param excludeId ID a excluir de la búsqueda (para updates), puede ser null
+   * @return true si existe otro empleado con esos nombres y apellidos
+   */
+  public boolean existsByNombresApellidos(String nombres, String apellidos, Integer excludeId) {
+    return TransactionHandler.inTransaction(
+        db,
+        em -> {
+          String jpql =
+              "SELECT COUNT(e) FROM Empleado e WHERE LOWER(e.nombres) = LOWER(:nombres) AND LOWER(e.apellidos) = LOWER(:apellidos)";
+          if (excludeId != null) {
+            jpql += " AND e.id <> :excludeId";
+          }
+          TypedQuery<Long> q = em.createQuery(jpql, Long.class);
+          q.setParameter("nombres", nombres.trim());
+          q.setParameter("apellidos", apellidos.trim());
+          if (excludeId != null) {
+            q.setParameter("excludeId", excludeId);
+          }
+          return q.getSingleResult() > 0;
+        });
+  }
 }


### PR DESCRIPTION
This pull request adds stricter validation to prevent duplicate entries for both clients and employees based on their identification number (cédula) and the combination of names and surnames. It introduces new repository methods for efficient duplicate checks and refactors controller logic to use these methods. Additionally, it sets a default state for new employees if none is provided.

### Duplicate validation enhancements

* Added new validation in `ClienteController` and `PersonalController` to prevent creation or update of clients and employees with duplicate cédula or with the same names and surnames, using newly introduced repository methods. [[1]](diffhunk://#diff-667a7efd72ec655aa1b461f40af4087e62fe51bcc44d7c93f32decad9d7dc267R70) [[2]](diffhunk://#diff-667a7efd72ec655aa1b461f40af4087e62fe51bcc44d7c93f32decad9d7dc267R104) [[3]](diffhunk://#diff-667a7efd72ec655aa1b461f40af4087e62fe51bcc44d7c93f32decad9d7dc267L193-R212) [[4]](diffhunk://#diff-14ea61ca0e23cef9af8170ada13905edb58d5d83d2a0c614e55998d55026752cR105-R106) [[5]](diffhunk://#diff-14ea61ca0e23cef9af8170ada13905edb58d5d83d2a0c614e55998d55026752cR126-R127) [[6]](diffhunk://#diff-14ea61ca0e23cef9af8170ada13905edb58d5d83d2a0c614e55998d55026752cR297-R324)

### Repository improvements

* Implemented `existsByCedula` and `existsByNombresApellidos` methods in both `ClienteRepository` and `EmpleadoRepository` for efficient duplicate checks, supporting exclusion of the current record during updates. [[1]](diffhunk://#diff-13f211d32d6341a4352445c9a820a2d8a9545a4b4e4362741639f7aad2188898R286-R336) [[2]](diffhunk://#diff-5eb2fc4b374021fee4eeb375535f8778e94c7807664360a31b169236b0be06fdR334-R384)

### Data consistency

* In `EmpleadoMapper`, set the default employee state to `ACTIVO` if no state is specified during creation.
* Added missing import for `EstadoEmpleado` in `EmpleadoMapper.java`.